### PR TITLE
Refactor log level mapping to use LogMessage constants

### DIFF
--- a/make87/handlers/__init__.py
+++ b/make87/handlers/__init__.py
@@ -1,7 +1,9 @@
+from make87_messages.text.log_message_pb2 import LogMessage
+
 LEVEL_MAPPING = {
-    "DEBUG": 10,
-    "INFO": 20,
-    "WARNING": 30,
-    "ERROR": 40,
-    "CRITICAL": 50,
+    "DEBUG": LogMessage.DEBUG,
+    "INFO": LogMessage.INFO,
+    "WARNING": LogMessage.WARNING,
+    "ERROR": LogMessage.ERROR,
+    "CRITICAL": LogMessage.CRITICAL,
 }


### PR DESCRIPTION
old integer values were incorrect. now they're tied to the actual proto message for consistency.